### PR TITLE
 Update key generation command. Add docker compose information

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,22 @@
 # Docker version of a Handle Server
 
-This is a docker version of the handle server software at http://www.handle.net/
+This is a docker version of the handle server software at <http://www.handle.net/>
 All information for how to use a handle server should be via the handle.net
 server documentation and support systems.
 
 This is a docker image with an embedded configuration script that is run on docker
 start to load default settings from environment variables.
 
+## Starting
+
+Use Docker compose to start the server.
+
+    docker compose up
+
+For for overriding evn variables see [Environment variables in Compose](https://docs.docker.com/compose/environment-variables/).
+
 # Configuration
+
 Configuration follows the same rules as the main handle configuration however with environments, see official documentation for more detailed configuration details.
 
 | Config                        | Default       | Required  | Description
@@ -39,7 +48,7 @@ The PRIVATE_KEY and PUBLIC_KEY need to be in pksc8 format, below is an example t
 
 Generate keypair
 
-    ssh-keygen -f mykey.pem
+    ssh-keygen -m pkcs8 -f mykey.pem
 
 Get it in a format for PKCS8 and put in explicit new lines ready for env var
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

This pull request is small improvements to the readme file
1. Make pkcs8 explicit when using ssh-keygen. On my ubuntu system the default isn't pkcs8 
2. Add a little info about docker compose to make things easier
3. Small formatting changes

## Approach
I just tried to improve the readme to include parts I didn't understand first time trying to get the server running 

#### Open Questions and Pre-Merge TODOs
- [ ] Review readme.md changes
- [ ] Test ssh-keygen command on OS version you use to run the handle proxy

## Learning
N/A

## Types of changes

- [X] Documentation improvements  (non-breaking change which fixes an issue)

